### PR TITLE
Make the comma optional in the Kaazing code.quality standard to cover gateway and other projects

### DIFF
--- a/src/main/resources/org/kaazing/code/quality/checkstyle.xml
+++ b/src/main/resources/org/kaazing/code/quality/checkstyle.xml
@@ -20,7 +20,7 @@
   </module>
   <!-- Copyright headers -->
   <module name="RegexpSingleline">
-    <property name="format" value="^(\s|\*)*Copyright (\(c\) )?(2007\-)?[0-9]+, Kaazing Corporation\. All rights reserved\.\s*$"/>
+    <property name="format" value="^(\s|\*)*Copyright (\(c\) )?(2007\-)?[0-9]+(,)? Kaazing Corporation\. All rights reserved\.\s*$"/>
     <property name="minimum" value="1"/>
     <property name="maximum" value="1"/>
   </module>


### PR DESCRIPTION
Kaazing has newer projects (e.g. nuklei) and older products (e.g. gateway.server) that differ in whether or not a comma is required in the copyright header in each file.  By making the comma optional (no legal need to have it), we naturally support both comma and comma-less copyright headers.

I can see an argument that to avoid mixed commas and no-commas within one project, we should pick a way and stick with it.  However, I think the only time anyone edits these things after creation is to change years, so the risk of in-consistent headers within one project is very low.  This lets us get going with all the open-source repositories in a flexible way.
