### PR TITLE
Javadoc checks and suppressions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.kaazing</groupId>
     <artifactId>code.quality</artifactId>
     <packaging>jar</packaging>
-    <version>1.2-SNAPSHOT</version>
+    <version>develop-SNAPSHOT</version>
 
     <name>Code Quality</name>
     <description>Configuration for code quality tools such as Checkstyle, FindBugs and PMD.</description>

--- a/src/main/resources/org/kaazing/code/quality/checkstyle-suppressions.xml
+++ b/src/main/resources/org/kaazing/code/quality/checkstyle-suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <suppress checks="Javadoc.*" files=".+[\\/]internal[\\/].+" />
+    <suppress checks="Javadoc.*" files=".+[\\/]src[\\/]test[\\/].+" />
+</suppressions>

--- a/src/main/resources/org/kaazing/code/quality/checkstyle.xml
+++ b/src/main/resources/org/kaazing/code/quality/checkstyle.xml
@@ -1,116 +1,108 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2007-2012, Kaazing Corporation. All rights reserved.
-  -->
 <!DOCTYPE module PUBLIC
   "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
   "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
-<!--
-  <module name="com.kaazing.build.checkstyle.SuppressionFilter">
-    <property name="pattern" value="(test[^/]*/.*|LocalTimeProtocol|LinkedTransferQueue|Version|jzlib/.*|com/sun/nio/sctp/.*)\.java" />
-  </module>
--->
-  <module name="FileTabCharacter"/>
-<!--
-  <module name="JavadocPackage"/>
--->
-  <module name="NewlineAtEndOfFile">
-    <property name="lineSeparator" value="lf" />
-  </module>
-  <!-- Copyright headers -->
-  <module name="RegexpSingleline">
-    <property name="format" value="^(\s|\*)*Copyright (\(c\) )?(2007\-)?[0-9]+(,)? Kaazing Corporation\. All rights reserved\.\s*$"/>
-    <property name="minimum" value="1"/>
-    <property name="maximum" value="1"/>
-  </module>
-  <!-- Unmaintainable Javadoc tags -->
-  <module name="RegexpSingleline">
-    <property name="format" value="(@(author|version)|\(non-Javadoc\))"/>
-    <property name="ignoreCase" value="true"/>
-  </module>
-  <!-- Force svn:eol-style native line separator -->
-<!-- Disabled for now because Eclipse (m2e) chokes on it due to shipping with an earlier version of CheckStyle
-  <module name="com.kaazing.build.checks.NativeEndOfLineCheck"/>
--->
-  <!-- Trailing whitespace -->
-  <module name="RegexpSingleline">
-    <property name="format" value="\s+$"/>
-  </module> 
-  <!-- No more than 129 characters per line. -->
-  <module name="RegexpSingleline">
-    <property name="format" value="^.{130,}$"/>
-  </module> 
+    <!-- <module name="com.kaazing.build.checkstyle.SuppressionFilter"> <property 
+        name="pattern" value="(test[^/]*/.*|LocalTimeProtocol|LinkedTransferQueue|Version|jzlib/.*|com/sun/nio/sctp/.*)\.java" 
+        /> </module> -->
+    <module name="FileTabCharacter" />
+    <!-- <module name="JavadocPackage"/> -->
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
+    <!-- Copyright headers -->
+    <module name="RegexpSingleline">
+        <property name="format"
+            value="^(\s|\*)*Copyright (\(c\) )?(2007\-)?[0-9]+(,)? Kaazing Corporation\. All rights reserved\.\s*$" />
+        <property name="minimum" value="1" />
+        <property name="maximum" value="1" />
+    </module>
+    <!-- Unmaintainable Javadoc tags -->
+    <module name="RegexpSingleline">
+        <property name="format" value="(@(author|version)|\(non-Javadoc\))" />
+        <property name="ignoreCase" value="true" />
+    </module>
+    <!-- Force svn:eol-style native line separator -->
+    <!-- Disabled for now because Eclipse (m2e) chokes on it due to shipping 
+        with an earlier version of CheckStyle <module name="com.kaazing.build.checks.NativeEndOfLineCheck"/> -->
+    <!-- Trailing whitespace -->
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$" />
+    </module>
+    <!-- No more than 129 characters per line. -->
+    <module name="RegexpSingleline">
+        <property name="format" value="^.{130,}$" />
+    </module>
 
-  <module name="TreeWalker">
-    <module name="WhitespaceAfter"/>
-    <module name="WhitespaceAround">
-      <property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, DIV, DIV_ASSIGN, EQUAL, GE, GT, LAND, LCURLY, LE, LITERAL_ASSERT, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, RCURLY, SL, SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN, TYPE_EXTENSION_AND, DEC, INC"/>
+    <module name="TreeWalker">
+        <module name="WhitespaceAfter" />
+        <module name="WhitespaceAround">
+            <property name="tokens"
+                value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, DIV, DIV_ASSIGN, EQUAL, GE, GT, LAND, LCURLY, LE, LITERAL_ASSERT, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, RCURLY, SL, SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN, TYPE_EXTENSION_AND, DEC, INC" />
+        </module>
+        <!-- Commented out due to false positives. <module name="MissingDeprecated"/> -->
+        <module name="MissingOverride" />
+        <module name="PackageAnnotation" />
+        <module name="EmptyBlock">
+            <property name="option" value="text" />
+        </module>
+        <module name="LeftCurly" />
+        <module name="RightCurly">
+            <property name="option" value="alone" />
+            <property name="tokens" value="LITERAL_ELSE" />
+        </module>
+        <module name="NeedBraces" />
+        <module name="AvoidNestedBlocks">
+            <property name="allowInSwitchCase" value="true" />
+        </module>
+        <module name="FinalClass" />
+        <module name="InterfaceIsType" />
+        <module name="HideUtilityClassConstructor" />
+        <module name="CovariantEquals" />
+        <!--module name="DoubleCheckedLocking"/ -->
+        <module name="EmptyStatement" />
+        <module name="EqualsHashCode" />
+        <!-- <module name="FinalLocalVariable"/> -->
+        <!-- Commented out due to http://jira.codehaus.org/browse/MCHECKSTYLE-111 
+            <module name="RedundantThrows"> <property name="logLoadErrors" value="false"/> 
+            <property name="suppressLoadErrors" value="true"/> </module> -->
+        <module name="SimplifyBooleanExpression" />
+        <module name="SimplifyBooleanReturn" />
+        <module name="NoFinalizer" />
+        <module name="SuperClone" />
+        <module name="SuperFinalize" />
+        <module name="PackageDeclaration" />
+        <module name="ExplicitInitialization" />
+        <module name="DefaultComesLast" />
+        <module name="UnnecessaryParentheses" />
+        <module name="AvoidStarImport">
+            <property name="allowStaticMemberImports" value="true" />
+        </module>
+        <module name="RedundantImport" />
+        <!-- Commented out due to false positives. <module name="UnusedImports"> 
+            <property name="processJavadoc" value="true"/> </module> -->
+        <module name="JavadocStyle">
+            <property name="checkFirstSentence" value="false" />
+        </module>
+        <module name="UpperEll" />
+        <module name="ArrayTypeStyle" />
+        <module name="OuterTypeFilename" />
+        <module name="ModifierOrder" />
+        <module name="RedundantModifier" />
+        <module name="GenericWhitespace" />
+        <module name="EmptyForInitializerPad" />
+        <module name="EmptyForIteratorPad" />
+        <module name="MethodParamPad" />
+        <module name="ParenPad" />
+        <module name="TypecastParenPad" />
+        <module name="JavadocType" />
+        <module name="JavadocVariable">
+            <property name="scope" value="public" />
+        </module>
+        <module name="JavadocStyle" />
+        <module name="JavadocMethod">
+            <property name="allowMissingJavadoc" value="true" />
+        </module>
     </module>
-    <!-- Commented out due to false positives.
-    <module name="MissingDeprecated"/>
-    -->
-    <module name="MissingOverride"/>
-    <module name="PackageAnnotation"/>
-    <module name="EmptyBlock">
-      <property name="option" value="text"/>
-    </module>
-    <module name="LeftCurly"/>
-    <module name="RightCurly">
-      <property name="option" value="alone"/>
-      <property name="tokens" value="LITERAL_ELSE"/>
-    </module>
-    <module name="NeedBraces"/>
-    <module name="AvoidNestedBlocks">
-      <property name="allowInSwitchCase" value="true"/>
-    </module>
-    <module name="FinalClass"/>
-    <module name="InterfaceIsType"/>
-    <module name="HideUtilityClassConstructor"/>
-    <module name="CovariantEquals"/>
-    <!--module name="DoubleCheckedLocking"/-->
-    <module name="EmptyStatement"/>
-    <module name="EqualsHashCode"/>
-    <!--
-    <module name="FinalLocalVariable"/>
-    -->
-    <!-- Commented out due to http://jira.codehaus.org/browse/MCHECKSTYLE-111
-    <module name="RedundantThrows">
-      <property name="logLoadErrors" value="false"/>
-      <property name="suppressLoadErrors" value="true"/>
-    </module>
-    -->
-    <module name="SimplifyBooleanExpression"/>
-    <module name="SimplifyBooleanReturn"/>
-    <module name="NoFinalizer"/>
-    <module name="SuperClone"/>
-    <module name="SuperFinalize"/>
-    <module name="PackageDeclaration"/>
-    <module name="ExplicitInitialization"/>
-    <module name="DefaultComesLast"/>
-    <module name="UnnecessaryParentheses"/>
-    <module name="AvoidStarImport">
-      <property name="allowStaticMemberImports" value="true"/>
-    </module>
-    <module name="RedundantImport"/>
-    <!-- Commented out due to false positives.
-    <module name="UnusedImports">
-      <property name="processJavadoc" value="true"/>
-    </module>
-    -->
-    <module name="JavadocStyle">
-      <property name="checkFirstSentence" value="false"/>
-    </module>
-    <module name="UpperEll"/>
-    <module name="ArrayTypeStyle"/>
-    <module name="OuterTypeFilename"/>
-    <module name="ModifierOrder"/>
-    <module name="RedundantModifier"/>
-    <module name="GenericWhitespace"/>
-    <module name="EmptyForInitializerPad"/>
-    <module name="EmptyForIteratorPad"/>
-    <module name="MethodParamPad"/>
-    <module name="ParenPad"/>
-    <module name="TypecastParenPad"/>
-  </module>
 </module>


### PR DESCRIPTION
Related update to community plugin coming soon.  The checks fail on netx.http only for one class

```
/Users/David/Documents/projects/netx.http/src/main/java/org/kaazing/netx/http/HttpURLConnection.java:25: Missing a Javadoc comment.
```

This is because HttpURLConnection has no javadoc (even though its an abstract class).  Maybe we want to change the javadoc checks to not complain on that?
